### PR TITLE
Translated strings in MapLocation to Spanish

### DIFF
--- a/Examples/MapLocation/res/values-es/strings.xml
+++ b/Examples/MapLocation/res/values-es/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="show_map_string">Ver la Mapa</string>
+    <string name="location_string">Escriba Ubicación</string>
+</resources>


### PR DESCRIPTION
Added my own values-es folder for Spanish strings, just to test it out.
