### PR TITLE
Package name mismatch fixed

### DIFF
--- a/Examples/NotificationStatusBarWithCustomView/src/course/examples/notification/statusbarwithcustomview/NotificationStatusBarWithCustomViewActivity.java
+++ b/Examples/NotificationStatusBarWithCustomView/src/course/examples/notification/statusbarwithcustomview/NotificationStatusBarWithCustomViewActivity.java
@@ -36,7 +36,7 @@ public class NotificationStatusBarWithCustomViewActivity extends Activity {
 	private long[] mVibratePattern = { 0, 200, 200, 300 };
 
 	RemoteViews mContentView = new RemoteViews(
-			"course.examples.Notification.StatusBarWithCustomView",
+			"course.examples.notification.statusbarwithcustomview",
 			R.layout.custom_notification);
 
 	@Override


### PR DESCRIPTION
Different packageName string with the actual package causes the app to crash on run time.
Testing platform: Nexus 5 version 5.1