### PR TITLE
bug fix: fragments are duplicated and overlaped

### DIFF
--- a/Examples/FragmentProgrammaticLayout/src/course/examples/Fragments/ProgrammaticLayout/QuoteViewerActivity.java
+++ b/Examples/FragmentProgrammaticLayout/src/course/examples/Fragments/ProgrammaticLayout/QuoteViewerActivity.java
@@ -26,6 +26,10 @@ public class QuoteViewerActivity extends Activity implements ListSelectionListen
 		
 		setContentView(R.layout.main);
 
+		if(savedInstanceState != null) {
+			return;
+		}
+
 		// Get a reference to the FragmentManager
 		FragmentManager fragmentManager = getFragmentManager();
 		


### PR DESCRIPTION
Hi, professor. 
In `FragmentProgrammaticLayout`, the main Activity would add fragment whenever `onCreate` is invoked. As a result, when `onCreate` is invoked by configuration changing, duplicated fragments would be added and overlapped. 
Here are the screenshots.Before configuration change:
![device-2016-08-28-223937](https://cloud.githubusercontent.com/assets/4540128/18034585/71f17a9a-6d73-11e6-9214-0db43451e808.png)
After configuration change(since new fragment is overlapped with old fragment, multiple items in the list appear to be selected):
![device-2016-08-28-224056](https://cloud.githubusercontent.com/assets/4540128/18034588/76de096a-6d73-11e6-82ed-eee95b24c395.png)

